### PR TITLE
Add session expiration date notification and session renewal logic

### DIFF
--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -8,17 +8,85 @@
   Copyright Contributors to the Zowe Project.
 */
 
+const DEFAULT_EXPIRATION_MS = 3600000 //hour;
+
 function ZssAuthenticator(pluginDef, pluginConf, serverConf) {
   this.authPluginID = pluginDef.identifier;
+  this.sessionExpirationMS = DEFAULT_EXPIRATION_MS; //ahead of time assumption of unconfigurable zss session length
 }
 
 ZssAuthenticator.prototype = {
 
-  getStatus(sessionState) {
-    return {  
-      authenticated: !!sessionState.authenticated, 
-      username: sessionState.zssUsername
-    };
+  getStatus(request, sessionState) {
+    return new Promise((resolve, reject) => {
+      this._authenticateOrRefresh(request, sessionState, true).then((response) => {
+        resolve(response);
+      }).catch ((e)=> {
+        //dont un-auth or delete cookie... perhaps this was a network error.
+        //Let session expire naturally if no success
+        resolve({ authenticated: false }) 
+      });
+    });
+  },
+
+  _authenticateOrRefresh(request, sessionState, isRefresh) {
+    return new Promise((resolve, reject) => {
+      if (isRefresh && !sessionState.zssCookies) {
+        reject(new Error('No cookie given for refresh or check, skipping zss request'));
+        return;
+      }
+      let options = isRefresh ? {
+        method: 'GET',
+        headers: {'cookie': sessionState.zssCookies}
+      } : {
+        method: 'POST',
+        body: request.body
+      };
+      request.zluxData.webApp.callRootService("login", options).then((response) => {
+        let zssCookie;
+        if (typeof response.headers['set-cookie'] === 'object') {
+          for (const cookie of response.headers['set-cookie']) {
+            const content = cookie.split(';')[0];
+            //TODO proper manage cookie expiration
+            if (content.indexOf('jedHTTPSession') >= 0) {
+              zssCookie = content;
+            }
+          }
+        }
+        if (zssCookie) {
+          if (!isRefresh) {
+            sessionState.zssUsername = request.body.username;
+          }
+          sessionState.authenticated = true;
+          sessionState.zssSessionEstablishedms = Date.now();
+          sessionState.zssCookies = zssCookie;                         //intended to be known as result of network call
+          resolve({ success: true, username: sessionState.zssUsername, expms: DEFAULT_EXPIRATION_MS })
+        } else {
+          sessionState.authenticated = false;
+          delete sessionState.zssUsername;
+          delete sessionState.zssCookies;
+          if (response.statusCode === 500) {
+            resolve({ success: false, reason: 'ConnectionError'});
+          } else {
+            resolve({ success: false});
+          }
+        }
+      }).catch((e) =>  {
+        reject(e);
+      });
+    });
+  },
+
+  refreshStatus(request, sessionState) {
+    return new Promise((resolve, reject) => {
+      this._authenticateOrRefresh(request, sessionState, true).then((response) => {
+        resolve(response);
+      }).catch ((e)=> {
+        console.log(e);
+        //dont un-auth or delete cookie... perhaps this was a network error. Let session expire naturally if no success
+        resolve({ success: false }) 
+      });
+    });
   },
   
   /**
@@ -35,36 +103,9 @@ ZssAuthenticator.prototype = {
    */ 
   authenticate(request, sessionState) {
     return new Promise((resolve, reject) => {
-    request.zluxData.webApp.callRootService("login", { 
-      method: "POST",
-      body: request.body
-    }).then((response) => {
-        let zssCookie;
-        if (typeof response.headers['set-cookie'] === 'object') {
-          for (const cookie of response.headers['set-cookie']) {
-            const content = cookie.split(';')[0];
-            //TODO proper manage cookie expiration
-            if (content.indexOf('jedHTTPSession') >= 0) {
-              zssCookie = content;
-            }
-          }
-        }
-        if (zssCookie) {
-          sessionState.zssUsername = request.body.username;
-          sessionState.authenticated = true;
-          sessionState.zssCookies = zssCookie;
-          resolve({ success: true, username: sessionState.zssUsername })
-        } else {
-          sessionState.authenticated = false;
-          delete sessionState.zssUsername;
-          delete sessionState.zssCookies;
-          if (response.statusCode === 500) {
-            resolve({ success: false, reason: 'ConnectionError'});
-          } else {
-            resolve({ success: false});
-          }
-        }
-      }).catch((e) =>  { 
+      this._authenticateOrRefresh(request, sessionState, false).then((response) => {
+        resolve(response);
+      }).catch ((e)=> {
         console.log(e);
         sessionState.authenticated = false;
         delete sessionState.zssUsername;

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -17,16 +17,19 @@ function ZssAuthenticator(pluginDef, pluginConf, serverConf) {
 
 ZssAuthenticator.prototype = {
 
-  getStatus(request, sessionState) {
-    return new Promise((resolve, reject) => {
-      this._authenticateOrRefresh(request, sessionState, true).then((response) => {
-        resolve(response);
-      }).catch ((e)=> {
-        //dont un-auth or delete cookie... perhaps this was a network error.
-        //Let session expire naturally if no success
-        resolve({ authenticated: false }) 
-      });
-    });
+  getStatus(sessionState) {
+    const expms = sessionState.sessionExpTime - Date.now();
+    if (expms <= 0 || sessionState.sessionExpTime === undefined) {
+      sessionState.authenticated = false;
+      delete sessionState.zssUsername;
+      delete sessionState.zssCookies;
+      return { authenticated: false };
+    }
+    return {  
+      authenticated: !!sessionState.authenticated, 
+      username: sessionState.zssUsername,
+      expms: sessionState.sessionExpTime ? expms : undefined
+    };
   },
 
   _authenticateOrRefresh(request, sessionState, isRefresh) {
@@ -58,7 +61,7 @@ ZssAuthenticator.prototype = {
             sessionState.zssUsername = request.body.username;
           }
           sessionState.authenticated = true;
-          sessionState.zssSessionEstablishedms = Date.now();
+          sessionState.sessionExpTime = Date.now() + DEFAULT_EXPIRATION_MS;
           sessionState.zssCookies = zssCookie;                         //intended to be known as result of network call
           resolve({ success: true, username: sessionState.zssUsername, expms: DEFAULT_EXPIRATION_MS })
         } else {
@@ -78,15 +81,11 @@ ZssAuthenticator.prototype = {
   },
 
   refreshStatus(request, sessionState) {
-    return new Promise((resolve, reject) => {
-      this._authenticateOrRefresh(request, sessionState, true).then((response) => {
-        resolve(response);
-      }).catch ((e)=> {
+      return this._authenticateOrRefresh(request, sessionState, true).catch ((e)=> {
         console.log(e);
         //dont un-auth or delete cookie... perhaps this was a network error. Let session expire naturally if no success
-        resolve({ success: false }) 
+        return { success: false };
       });
-    });
   },
   
   /**
@@ -102,16 +101,12 @@ ZssAuthenticator.prototype = {
    * { success: true }. Should not reject the promise.
    */ 
   authenticate(request, sessionState) {
-    return new Promise((resolve, reject) => {
-      this._authenticateOrRefresh(request, sessionState, false).then((response) => {
-        resolve(response);
-      }).catch ((e)=> {
-        console.log(e);
-        sessionState.authenticated = false;
-        delete sessionState.zssUsername;
-        delete sessionState.zssCookies;
-        resolve({ success: false }) 
-      });
+    return this._authenticateOrRefresh(request, sessionState, false).catch ((e)=> {
+      console.log(e);
+      sessionState.authenticated = false;
+      delete sessionState.zssUsername;
+      delete sessionState.zssCookies;
+      return { success: false };
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "author": "Fyodor Kovin <fkovn@rocketsoftware.com>",
   "dependencies": {


### PR DESCRIPTION
Add session expiration information so that the desktop can make informed decision about it. Make getStatus query zss. Add missing package-lock file.

Signed-off-by: Sean Grady <sgrady@rocketsoftware.com>