### PR TITLE
Added capabilities structure to constructor and getter for capabilities

### DIFF
--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -23,9 +23,20 @@ function ZssAuthenticator(pluginDef, pluginConf, serverConf) {
   this.resourceClass = DEFAULT_CLASS;
   this.sessionExpirationMS = DEFAULT_EXPIRATION_MS; //ahead of time assumption of unconfigurable zss session length
   this.instanceID = serverConf.instanceID;
+  this.capabilities = {
+    "canGetStatus": true,
+    "canRefresh": true,
+    "canAuthenticate": true,
+    "canAuthorize": true,
+    "proxyAuthorizations": true
+  };
 }
 
 ZssAuthenticator.prototype = {
+
+  getCapabilities(){
+    return this.capabilities;
+  },
 
   getStatus(sessionState) {
     const expms = sessionState.sessionExpTime - Date.now();


### PR DESCRIPTION
Used by server framework to determine the capabilities of an authentication handler when calling authenticate() or refreshStatus() functions. 
Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>