### PR TITLE
RBAC support for root services

### DIFF
--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -107,6 +107,9 @@ function makeProfileName(type, parms) {
       profileName += '.' + usableParts.join('.');
     }
   }
+  if(type === 'core'){
+    profileName = profileName.replace(/\*/g, '%2A');
+  }
   return profileName;
 }
 

--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -111,26 +111,24 @@ function makeProfileName(type, parms) {
 }
 
 function makeProfileNameForRequest(url, method, instanceID) {
+  let urlData;
+  let instanceID;
+  let type;
   if (!url.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
     url = url.toUpperCase();
-    let urlData;
-    let instanceID;
+    type = "core";
     let splitUrl = url.split('/');
     splitUrl = splitUrl.filter(x => x);
     let productCode = "ZLUX";
-    let type = "core";
     let rootServiceName = splitUrl[0];
     let subUrl = splitUrl.slice(1);
     if (!instanceID) {
       instanceID = DEFAULT_INSTANCE_ID;
     }
     urlData = { productCode, instanceID, rootServiceName, method, subUrl };
-    return makeProfileName(type, urlData);
   } else {
     url = url.toUpperCase();
     let [_l, productCode, _p, pluginID, _s, serviceName, _v, ...subUrl] = url.split('/');
-    let type;
-    let urlData;
     if (!instanceID) {
       instanceID = DEFAULT_INSTANCE_ID;
     }
@@ -146,8 +144,8 @@ function makeProfileNameForRequest(url, method, instanceID) {
       urlData = { productCode, instanceID, pluginID, serviceName, method, subUrl };
     }
     urlData.pluginID = urlData.pluginID? urlData.pluginID.replace(/\./g, "_") : null;
-    return makeProfileName(type, urlData);
   }
+  return makeProfileName(type, urlData);
 };
 
 exports.makeProfileNameForRequest = makeProfileNameForRequest;

--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -26,6 +26,23 @@ function partsUpToTotalLength(parts, maxLen) {
   return outParts;
 }
 
+function rootServiceProfileName(parms){
+  if (parms.productCode == null) {
+    throw new Error("productCode missing");
+  }
+  if (parms.instanceID == null) {
+    throw new Error("instanceID missing");
+  }
+  if (parms.rootServiceName == null) {
+    throw new Error("rootServiceName missing");
+  }
+  if (parms.method == null) {
+    throw new Error("method missing");
+  }
+  return `${parms.productCode}.${parms.instanceID}.COR`
+      + `.${parms.method}.${parms.rootServiceName}`;
+}
+
 function serviceProfileName(parms) {
   if (parms.productCode == null) {
     throw new Error("productCode missing");
@@ -67,7 +84,18 @@ function configProfileName(parms) {
 }
 
 function makeProfileName(type, parms) {
-  const makeProfileName = (type == "service")? serviceProfileName : configProfileName;
+  let makeProfileName;
+  switch(type){
+    case "service":
+      makeProfileName = serviceProfileName;
+      break;
+    case "config":
+      makeProfileName = configProfileName;
+      break;
+    case "core":
+      makeProfileName = rootServiceProfileName;
+      break;
+  }
   let profileName = makeProfileName(parms);
   if (profileName.length > ZOWE_PROFILE_NAME_LEN) {
     throw new Error("SAF resource name too long");
@@ -83,26 +111,43 @@ function makeProfileName(type, parms) {
 }
 
 function makeProfileNameForRequest(url, method, instanceID) {
-  url = url.toUpperCase();
-  let [_l, productCode, _p, pluginID, _s, serviceName, _v, ...subUrl] = url.split('/');
-  let type;
-  let urlData;
-  if (!instanceID) {
-    instanceID = DEFAULT_INSTANCE_ID;
-  }
-  subUrl = subUrl.filter(x => x);
-  if ((pluginID === "ORG.ZOWE.CONFIGJS") && (serviceName === "DATA")) {
-    type = "config";
-    pluginID = subUrl[0];
-    let scope = subUrl[1];
-    subUrl = subUrl.slice(2);
-    urlData = { productCode, instanceID, pluginID, method, scope, subUrl };
+  if (!url.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
+    url = url.toUpperCase();
+    let urlData;
+    let instanceID;
+    let splitUrl = url.split('/');
+    splitUrl = splitUrl.filter(x => x);
+    let productCode = "ZLUX";
+    let type = "core";
+    let rootServiceName = splitUrl[0];
+    let subUrl = splitUrl.slice(1);
+    if (!instanceID) {
+      instanceID = DEFAULT_INSTANCE_ID;
+    }
+    urlData = { productCode, instanceID, rootServiceName, method, subUrl };
+    return makeProfileName(type, urlData);
   } else {
-    type = "service";
-    urlData = { productCode, instanceID, pluginID, serviceName, method, subUrl };
+    url = url.toUpperCase();
+    let [_l, productCode, _p, pluginID, _s, serviceName, _v, ...subUrl] = url.split('/');
+    let type;
+    let urlData;
+    if (!instanceID) {
+      instanceID = DEFAULT_INSTANCE_ID;
+    }
+    subUrl = subUrl.filter(x => x);
+    if ((pluginID === "ORG.ZOWE.CONFIGJS") && (serviceName === "DATA")) {
+      type = "config";
+      pluginID = subUrl[0];
+      let scope = subUrl[1];
+      subUrl = subUrl.slice(2);
+      urlData = { productCode, instanceID, pluginID, method, scope, subUrl };
+    } else {
+      type = "service";
+      urlData = { productCode, instanceID, pluginID, serviceName, method, subUrl };
+    }
+    urlData.pluginID = urlData.pluginID? urlData.pluginID.replace(/\./g, "_") : null;
+    return makeProfileName(type, urlData);
   }
-  urlData.pluginID = urlData.pluginID? urlData.pluginID.replace(/\./g, "_") : null;
-  return makeProfileName(type, urlData);
 };
 
 exports.makeProfileNameForRequest = makeProfileNameForRequest;

--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -112,7 +112,6 @@ function makeProfileName(type, parms) {
 
 function makeProfileNameForRequest(url, method, instanceID) {
   let urlData;
-  let instanceID;
   let type;
   if (!url.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
     url = url.toUpperCase();

--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -107,9 +107,6 @@ function makeProfileName(type, parms) {
       profileName += '.' + usableParts.join('.');
     }
   }
-  if(type === 'core'){
-    profileName = profileName.replace(/\*/g, '%2A');
-  }
   return profileName;
 }
 

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -173,15 +173,6 @@ ZssAuthenticator.prototype = {
         this._allowIfLoopback(request, result);
         return result;
       }
-      if (!request.originalUrl.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
-        // RBAC for root services is not supported
-        //This comment was left so that future resource/profile names can be viewed in the log for documentation 
-        // const resourceName = this._makeProfileName(request.originalUrl, 
-        //   request.method);
-        // console.log("Created RBAC resourceName: ", resourceName, " for URL ", request.originalUrl);
-        result.authorized = true;
-        return result;
-      }
       const resourceName = this._makeProfileName(request.originalUrl, 
           request.method);
       if (syncOnly) {

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -174,7 +174,11 @@ ZssAuthenticator.prototype = {
         return result;
       }
       if (!request.originalUrl.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
-        // RBAC for root services is not supported 
+        // RBAC for root services is not supported
+        //This comment was left so that future resource/profile names can be viewed in the log for documentation 
+        // const resourceName = this._makeProfileName(request.originalUrl, 
+        //   request.method);
+        // console.log("Created RBAC resourceName: ", resourceName, " for URL ", request.originalUrl);
         result.authorized = true;
         return result;
       }

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -228,6 +228,7 @@ ZssAuthenticator.prototype = {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
     resourceName = encodeURIComponent(resourceName);
+    resourceName = resourceName.replace(/\*/g, '2A');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -228,7 +228,6 @@ ZssAuthenticator.prototype = {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
     resourceName = encodeURIComponent(resourceName);
-    resourceName = resourceName.replace(/\*/g, '2A');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))


### PR DESCRIPTION
This change enables the creation of RBAC profile names for root services, following the previous naming scheme.  Works by adding "rbac" member to zluxserver config.