### PR TITLE
Bug fix: non server status REST API urls are authorized by default

### DIFF
--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -179,7 +179,8 @@ ZssAuthenticator.prototype = {
         '/VSAMdatasetContents',
         '/datasetMetadata',
         '/omvs',
-        '/security-mgmt'
+        '/security-mgmt',
+        '/logout'
       ]
       for(let i = 0; i < bypassUrls.length; i++){
         if(request.originalUrl.startsWith(bypassUrls[i])){

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -173,6 +173,22 @@ ZssAuthenticator.prototype = {
         this._allowIfLoopback(request, result);
         return result;
       }
+      let bypassUrls = [
+        '/unixfile',
+        '/datasetContents',
+        '/VSAMdatasetContents',
+        '/datasetMetadata',
+        '/config',
+        '/omvs',
+        '/ras',
+        '/security-mgmt'
+      ]
+      for(let i = 0; i < bypassUrls.length; i++){
+        if(request.originalUrl.startsWith(bypassUrls[i])){
+          result.authorized = true;
+          return result;
+        }
+      }
       const resourceName = this._makeProfileName(request.originalUrl, 
           request.method);
       if (syncOnly) {

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -178,9 +178,7 @@ ZssAuthenticator.prototype = {
         '/datasetContents',
         '/VSAMdatasetContents',
         '/datasetMetadata',
-        '/config',
         '/omvs',
-        '/ras',
         '/security-mgmt'
       ]
       for(let i = 0; i < bypassUrls.length; i++){


### PR DESCRIPTION
This pull request fixes a bug where previous root services were not authorized by default following changes to the RBAC profile name generation.
URLs that are automatically authorized:
/unixfile
/datasetContents
/VSAMdatasetContents
/datasetMetadata
/omvs
/security-mgmt
/logout

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>