### PR TITLE
Special char url

### DIFF
--- a/lib/safprofile.js
+++ b/lib/safprofile.js
@@ -113,6 +113,7 @@ function makeProfileName(type, parms) {
 function makeProfileNameForRequest(url, method, instanceID) {
   let urlData;
   let type;
+  url=decodeURIComponent(url);
   if (!url.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
     url = url.toUpperCase();
     type = "core";

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -265,7 +265,7 @@ ZssAuthenticator.prototype = {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
     resourceName = encodeURI(resourceName);
-    resourceName = resourceName.replace('%',':');
+    resourceName = resourceName.replace(/%/g,':');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -264,8 +264,8 @@ ZssAuthenticator.prototype = {
   _callAgent(zluxData, userName, resourceName) {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
-    resourceName = encodeURIComponent(resourceName);
-    resourceName = resourceName.replace('%',':');
+    resourceName = encodeURI(resourceName);
+    //resourceName = resourceName.replace('%',':');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -265,7 +265,7 @@ ZssAuthenticator.prototype = {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
     resourceName = encodeURI(resourceName);
-    //resourceName = resourceName.replace('%',':');
+    resourceName = resourceName.replace('%',':');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))

--- a/lib/zssAuth.js
+++ b/lib/zssAuth.js
@@ -197,9 +197,11 @@ ZssAuthenticator.prototype = {
         result.authorized = true;
         return result;
       }
+      //log.info(`saf-auth: username:${sessionState.zssUsername}, resource:${resourceName}`);
       const httpResponse = yield this._callAgent(request.zluxData, 
           sessionState.zssUsername,  resourceName);
       this._processAgentResponse(httpResponse, result, sessionState.zssUsername);
+      //log.info(`saf-auth: result:${JSON.stringify(result)}, statusCode:${httpResponse.statusCode} response:${JSON.stringify(httpResponse.body)}}`);
       //console.log("returning result", result)
       return result;
     } catch (e) {
@@ -263,9 +265,11 @@ ZssAuthenticator.prototype = {
     //console.log("resourceName", resourceName)
     userName = encodeURIComponent(userName);
     resourceName = encodeURIComponent(resourceName);
+    resourceName = resourceName.replace('%',':');
     const path = `${resourceName}/READ`;
     //console.log('trying path ', path);
     //console.log(new Error("stack trace before calling root serivce"))
+    //log.info("path:", path);
     return zluxData.webApp.callRootService("saf-auth", path);
   },
   

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -159,6 +159,12 @@ describe('makeProfileNameForRequest', function() {
     const profile4 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.CO.RS.TEP.QUERYHANDLER:WORKSPACEMANAGER.LEVEL.3";
     const result4 = makeProfileNameForRequest(url4, "GET", "DEFAULT");
     assert(profile4 === result4);
+    
+    const url5 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/co.rs.tep.queryHandler:workspaceManager/level/3/get?foo1=bar1&foo2=bar2";
+    const profile5 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.CO.RS.TEP.QUERYHANDLER:WORKSPACEMANAGER.LEVEL.3.GET?FOO1=BAR1&FOO2=BAR2";
+    const result5 = makeProfileNameForRequest(url5, "GET", "DEFAULT");
+    assert(profile5 === result5);
+
   });
 
   it('should correctly generate config profiles with malformed url', function() {

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -154,6 +154,11 @@ describe('makeProfileNameForRequest', function() {
     const profile3 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U:USER";
     const result3 = makeProfileNameForRequest(url3, "GET", "DEFAULT");
     assert(profile3 === result3);
+
+    const url4 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/co.rs.tep.queryHandler:workspaceManager/level/3";
+    const profile4 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.CO.RS.TEP.QUERYHANDLER:WORKSPACEMANAGER.LEVEL.3";
+    const result4 = makeProfileNameForRequest(url4, "GET", "DEFAULT");
+    assert(profile4 === result4);
   });
 
   it('should correctly generate config profiles with malformed url', function() {

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -145,8 +145,9 @@ describe('makeProfileNameForRequest', function() {
     assert(profile1===result1);
 
     const url2 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/%2fu%2fuser";
-    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.%2FU.USER";
+    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U.USER";
     const result2 = makeProfileNameForRequest(url2, "GET", "DEFAULT");
+    console.log(result2);
     assert(profile2 === result2);
     
     const url3 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u:user";

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -138,6 +138,32 @@ describe('makeProfileNameForRequest', function() {
     assert(result4.length <= safprofile.ZOWE_PROFILE_NAME_LEN);
   });
   
-  
-  
+  it('should correctly generate config profiles with special characters', function() {
+    const url1 = "/ZLUX/plugins/org.zowe.configjs/services/data/_current/org.zowe.zlux.ng2desktop/user/ui/launchbar/plugins?name=pinnedPlugins.json";
+    const profile1 = "ZLUX.DEFAULT.CFG.ORG_ZOWE_ZLUX_NG2DESKTOP.GET.USER.UI.LAUNCHBAR.PLUGINS?NAME=PINNEDPLUGINS.JSON";
+    const result1 = makeProfileNameForRequest(url1, "GET", "DEFAULT");
+    assert(profile1===result1);
+
+    const url2 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/%2fu%2fuser";
+    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U.USER";
+    const result2 = makeProfileNameForRequest(url2, "GET", "DEFAULT");
+    assert(profile2 === result2);
+
+    const url3 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u:user";
+    const profile3 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U:USER";
+    const result3 = makeProfileNameForRequest(url3, "GET", "DEFAULT");
+    assert(profile3 === result3);
+  });
+
+  it('should correctly generate config profiles with malformed url', function() {
+    const url = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/%u%user";
+    const profile = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U.USER";
+    try {
+      makeProfileNameForRequest(url, "GET", "DEFAULT");
+      assert(false);
+    } catch(err) {
+      assert(true);
+    }
+  });
+
 });

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -149,11 +149,6 @@ describe('makeProfileNameForRequest', function() {
     const result2 = makeProfileNameForRequest(url2, "GET", "DEFAULT");
     assert(profile2 === result2);
     
-    const url2 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/jobs/J0006967/files";
-    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.JOBS.J0006967.FILES";
-    
-
-
     const url3 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u:user";
     const profile3 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U:USER";
     const result3 = makeProfileNameForRequest(url3, "GET", "DEFAULT");

--- a/test/safprofile-test.js
+++ b/test/safprofile-test.js
@@ -145,9 +145,14 @@ describe('makeProfileNameForRequest', function() {
     assert(profile1===result1);
 
     const url2 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/%2fu%2fuser";
-    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U.USER";
+    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.%2FU.USER";
     const result2 = makeProfileNameForRequest(url2, "GET", "DEFAULT");
     assert(profile2 === result2);
+    
+    const url2 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/jobs/J0006967/files";
+    const profile2 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.JOBS.J0006967.FILES";
+    
+
 
     const url3 = "/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u:user";
     const profile3 = "ZLUX.DEFAULT.SVC.ORG_ZOWE_ZLUX_ECHOSERVICE.HELLO.GET.SPECIAL.U:USER";


### PR DESCRIPTION
URL encoding with % sign were always returning with authorizatioz:false with RACF

Added two things to resolve the issue:
- **decodeURIComponent**   in makeProfileNameForRequest function, it gives chance to preserve original symbol, like number or slash etc
- resourceName.replace('%',':') - before sending this to RACF in callAgent function

@1000TurquoisePogs , it do increase the range of character we can map safely to RACF profile name
Enable log statements i left in comments in PR

**Other solution** could be to do decodeURIComponent   in makeProfileNameForRequest function, and use POST to zss instead of RACF, as you suggested in our discussion but we still need to encode % with some other symbol, here i am encoding this with ":" for no particular reason.

To test created echo service as you suggested, same as sample-angular-app, just replaced POST with GET
eg: https://localhost:8544/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u%3Auser
https://localhost:8544/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/u:user
https://localhost:8544/ZLUX/plugins/org.zowe.zlux.echoService/services/hello/_current/special/%2Fuser

Helper to try out various symbold from url encoding:
https://www.w3schools.com/tags/ref_urlencode.ASP